### PR TITLE
Fixed email change, changed index errors to POST

### DIFF
--- a/src/flaskcrudapp/app.py
+++ b/src/flaskcrudapp/app.py
@@ -74,7 +74,6 @@ Add a requester as a user in database and redirects to requester page.
 @app.route('/add', methods=['POST'])
 def add_user():
     _form = request.form
-
     _name = _form['name']
     _email = _form['email']
     _password = _form['pwd']
@@ -107,15 +106,20 @@ def appeal():
     _form = request.form 
     _worker_id = _form["turkerId"]
     _HIT_id = _form["HITId"]
+
     result = csvs_db.find_one({"WorkerId":_worker_id, "HITId":_HIT_id})
+    
     if not result:
         return (redirect(url_for('index', appealerror=True)))
+    
     sandbox_link = result['sandboxLink']
     status = result['Status']
+    
     try:
         worker_email = result['WorkerEmail'] 
     except:
         worker_email = ''
+    
     hit_data = {
         'HITId' : _HIT_id,
         'WorkerId' : _worker_id,
@@ -123,6 +127,7 @@ def appeal():
         'WorkerEmail' : worker_email,
         'Status' : status
     }
+
     session["sandboxLink"] = sandbox_link
     session['WorkerEmail'] = worker_email
     return (render_template('appeal.html', hit_data=hit_data))
@@ -137,6 +142,7 @@ def make_appeal():
     _explanation = _form["explanation"]
     _email = _form["email"] if _form["email"] else session['WorkerEmail']
     hit_id = create_appeal(sandbox_link=session["sandboxLink"], explanation=_explanation)
+    
     csvs_db.update_one(
         {
             "sandboxLink": session["sandboxLink"]
@@ -149,6 +155,7 @@ def make_appeal():
             }
         }
     )
+    
     entry = csvs_db.find_one({"AppealId":hit_id}, {"HITId":1})
     return redirect(url_for('index', appealsuccess=True, appealId=entry["HITId"]))
 
@@ -196,8 +203,10 @@ def upload():
     filename = file.filename
     batch_name = request.form['batch_name']
     requester_info = users_db.find_one({"req_id":session["req_id"]})
+
     if csvs_db.find_one({"batch_name":batch_name, "req_id":session["req_id"]}):
         return redirect(url_for('requester', batch_name_error=True))
+    
     if '.' in filename and filename.split(".")[-1] in ALLOWED_EXTENSIONS:
         rejected = parse_csv(input=file)
         batch_ids = set()

--- a/src/flaskcrudapp/app.py
+++ b/src/flaskcrudapp/app.py
@@ -21,13 +21,35 @@ users_db = mongo.db.users
 csvs_db = mongo.db.csvs
 
 
-@app.route('/')
+@app.route('/', methods=['GET', 'POST'])
 def index():
     if session.get('logged_in'):
         return redirect(url_for('requester'))
-    return (render_template('index.html', signupsuccess=request.args.get('signupsuccess'),
-            appealsuccess=request.args.get('appealsuccess'), appealId=request.args.get('appealId'),
-            signinerror=request.args.get('signinerror'), appealerror=request.args.get('appealerror')))
+
+    if request.method == 'POST':
+        signupsuccess = session['signupsuccess'] if 'signupsuccess' in session else None
+        signinerror = session['signinerror'] if 'signinerror' in session else None
+        
+        appealsuccess = session['appealsuccess'] if 'appealsuccess' in session else None
+        appealerror = session['appealerror'] if 'appealerror' in session else None
+
+        emailsuccess = session['emailsuccess'] if 'emailsuccess' in session else None
+        
+        HITId = session['HITId'] if 'HITId' in session else None
+        worker_email = session['WorkerEmail'] if 'WorkerEmail' in session else None
+
+        session.clear()
+
+        return (render_template('index.html',
+            signupsuccess=signupsuccess, signinerror=signinerror,
+            appealsuccess=appealsuccess, appealerror=appealerror,
+            emailsuccess=emailsuccess,
+            HITId=HITId, worker_email=worker_email
+        ))
+    
+    else:
+        return(render_template('index.html'))
+    
 
 '''
 Signin route.
@@ -46,7 +68,8 @@ def signin():
             session['logged_in'] = True
             return redirect(url_for('requester'))
         else:
-            return (redirect(url_for('index', signinerror=True)))
+            session['signinerror'] = True
+            return (redirect(url_for('index'), code=307))
     else:
         return not_found()
 
@@ -92,7 +115,7 @@ def add_user():
 
         resp = jsonify('User added successfully')
         resp.status_code = 200
-        return (redirect(url_for('index', signupsuccess=True)))
+        return (redirect(url_for('index')))
     
     else:
         return not_found()
@@ -110,7 +133,8 @@ def appeal():
     result = csvs_db.find_one({"WorkerId":_worker_id, "HITId":_HIT_id})
     
     if not result:
-        return (redirect(url_for('index', appealerror=True)))
+        session['appealerror'] = True
+        return (redirect(url_for('index'), code=307))
     
     sandbox_link = result['sandboxLink']
     status = result['Status']
@@ -129,7 +153,10 @@ def appeal():
     }
 
     session["sandboxLink"] = sandbox_link
-    session['WorkerEmail'] = worker_email
+    session["WorkerEmail"] = worker_email
+    session["WorkerId"] = _worker_id
+    session["HITId"] = _HIT_id
+
     return (render_template('appeal.html', hit_data=hit_data))
 
 
@@ -138,26 +165,56 @@ Submitting appeal
 '''
 @app.route('/makeappeal', methods=['POST'])
 def make_appeal():
-    _form = request.form 
-    _explanation = _form["explanation"]
+
+    # TODO: make sure this is called after the '/appeal' route or check that session vars are set
+
+    _form = request.form
     _email = _form["email"] if _form["email"] else session['WorkerEmail']
-    hit_id = create_appeal(sandbox_link=session["sandboxLink"], explanation=_explanation)
-    
-    csvs_db.update_one(
-        {
-            "sandboxLink": session["sandboxLink"]
-        }, 
-        {
-            "$set": {
-                "Status":"Under review", 
-                "AppealId":hit_id, 
-                "WorkerEmail":_email
+    _worker_id = session["WorkerId"]
+    _HIT_id = session["HITId"]
+
+    hit_data = csvs_db.find_one({"WorkerId":_worker_id, "HITId":_HIT_id})
+
+    if hit_data["Status"] == "NA":
+        _explanation = _form["explanation"]
+        appeal_id = create_appeal(sandbox_link=session["sandboxLink"], explanation=_explanation)
+
+        csvs_db.update_one(
+            {
+                "WorkerId" : _worker_id,
+                "HITId" : _HIT_id
+            }, 
+            {
+                "$set": {
+                    "Status":"Under review",
+                    "AppealId":appeal_id, 
+                    "WorkerEmail":_email,
+                    "Explanation":_explanation
+                }
             }
-        }
-    )
-    
-    entry = csvs_db.find_one({"AppealId":hit_id}, {"HITId":1})
-    return redirect(url_for('index', appealsuccess=True, appealId=entry["HITId"]))
+        )
+
+        session['appealsuccess'] = True
+
+        return redirect(url_for('index'), code=307)
+
+    else:
+        csvs_db.update_one(
+            {
+                "WorkerId" : _worker_id,
+                "HITId" : _HIT_id
+            }, 
+            {
+                "$set": {
+                    "WorkerEmail":_email,
+                }
+            }
+        )
+
+        session['emailsuccess'] = True
+        session['WorkerEmail'] = _email
+
+        return redirect(url_for('index'), code=307)
 
 
 '''

--- a/src/flaskcrudapp/templates/appeal.html
+++ b/src/flaskcrudapp/templates/appeal.html
@@ -2,7 +2,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Submit an Appeal</title>
+    <title>Appeal Dashboard</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css">
     <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
 </head>
@@ -10,31 +10,37 @@
   <section class="section">
 
     <br /> <br />
-    <h2 class="title" align="center">Submit an Appeal:</h2>
+    <h1 class="title is-2" align="center">Appeal Dashboard:</h1>
     <br />
-
     <div class="columns is-centered">
       <div class="column is-half">
+        <div class="box">
+          <h1  class="title is-3">Current appeal:</h1>
+          <p><strong>HIT ID:</strong> {{hit_data['HITId']}}</p>
+          <p><strong>Worker ID:</strong> {{hit_data['WorkerId']}}</p>
+          {% if hit_data['Status']!='NA' %}
+          <p><strong>Status:</strong> {{hit_data['Status']}}</p>
+          {% else %}
+          <p><strong>Status: </strong> Not yet appealed. You can appeal this HIT using the panel below.
+          <p><strong>Sandbox link to your original HIT: </strong><a href={{hit_data['sandboxLink']}}>here</a></p>
+          {% endif %}
+        </div>
         <form method="POST" action="/makeappeal" class="box">
 
-          <p><strong>HIT:</strong> {{hit_data['HITId']}}</p>
-          <p><strong>WorkerID:</strong> {{hit_data['WorkerId']}}</p>
-          {% if hit_data['Status']!='NA' %}
-          <p><strong>Status: </strong>{{hit_data['Status']}}</p>
-          {% else %}
-          <p><strong>Sandbox link: </strong><a href={{hit_data['sandboxLink']}}>here</a></p>
+          {% if hit_data['Status']=='NA' %}
           <div class="field">
             <label class="label">Explanation:</label>
             <div class="control">
-              <input type="text" placeholder="Requester sucks" class="input" name="explanation" required>
+              <input type="text" placeholder="e.g. The instructions were unclear" class="input" name="explanation" required>
             </div>
           </div>
           {% endif %}
           {% if hit_data['WorkerEmail']!="" %}
-          <p><strong>Is this still your preferred email:</strong> {{hit_data['WorkerEmail']}}? If not, enter a new one below.</p>
+          <p>Is <strong>{{hit_data['WorkerEmail']}}</strong> still your preferred email? If not, enter a new one below.</p>
+          <br/>
           {% endif %}
           <div class="field">
-            <label class="label">Enter an email to get updates about your appeal:</label>
+            <label class="label">Enter an email to get updates on your appeal:</label>
             <div class="control has-icons-left">
               <input type="email" placeholder="(Optional)" class="input" name="email">
               <span class="icon is-small is-left">
@@ -49,6 +55,7 @@
           </div>
 
         </form>
+        <p>Click <a href="/">here</a> to return to the home page.</p>
       </div>
     </div>
   </section>

--- a/src/flaskcrudapp/templates/index.html
+++ b/src/flaskcrudapp/templates/index.html
@@ -10,7 +10,7 @@
   <section class="section">
 
     <br /> <br />
-    <h2 class="title" align="center">Welcome to Turkish Judge!</h2>
+    <h2 class="title is-2" align="center">Welcome to Turkish Judge!</h2>
     <br />
 
     <div class="columns is-centered">

--- a/src/flaskcrudapp/templates/index.html
+++ b/src/flaskcrudapp/templates/index.html
@@ -83,7 +83,14 @@
           <br />
           {% endif %}
           {% if appealsuccess %}
-          <p class=error style="color:coral"><strong>Success: </strong>Your appeal has been posted. To check the status come back and enter your Turker ID and the HIT ID: {{appealId}}.</p>
+          <p class=error style="color:coral"><strong>Success: </strong>Your appeal has been posted. <br/><br/>
+          To check the status or change your associated email, come back and enter your Turker ID and the HIT ID: {{HITId}}.
+          </p>
+          <br />
+          {% endif %}
+          {% if emailsuccess %}
+          <p class=error style="color:coral"><strong>Success: </strong>Your associated email has been successfully updated to {{worker_email}}. <br/><br/>
+          To check the status or change your associated email, come back and enter your Turker ID and the HIT ID: {{HITId}}.</p>
           <br />
           {% endif %}
           <div class="field">

--- a/src/flaskcrudapp/templates/requester.html
+++ b/src/flaskcrudapp/templates/requester.html
@@ -9,7 +9,7 @@
 <body>
   <section class="section">
     <br /> <br />
-    <h2 class="title" align="center">Requesters</h2>
+    <h1 class="title is-2" align="center">Requesters</h1>
     <br />
     
     <div class="columns is-centered">

--- a/src/flaskcrudapp/templates/signUp.html
+++ b/src/flaskcrudapp/templates/signUp.html
@@ -10,13 +10,13 @@
   <section class="section">
 
     <br /> <br />
-    <h2 class="title" align="center">Create an Account</h2>
+    <h1 class="title is-2" align="center">Create an Account</h1>
     <br />
 
     <div class="columns is-centered">
       <div class="column is-one-third">
           <form method="POST" action="/add" class="box">
-              <p class="is-size-4">Create a Requester Account</p>
+              <p class="is-size-4">Register for a Requester Account:</p>
               <br/>
               <div class="field">
                 <label class="label">Name</label>


### PR DESCRIPTION
-> Workers can now properly change their emails after submitting an appeal
-> Added email success to index page
-> Changed errors and successes on index page to POST instead of GET and stored variables in session so they don't show in the URL
-> Explanations are now stored in the CSVs database when appeal is submitted